### PR TITLE
Switch execution order of testsuites, unit tests first

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,12 +9,12 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
Unit tests usually run faster and provide more fine-granular feedback if something is broken. If some small part of the application is broken, it may easily cause all the feature tests to fail, while not providing useful feedback.